### PR TITLE
added XMC1100_XMC2Go and XMC1400_XMC2GO  in btn99xx_dc_shield.cpp

### DIFF
--- a/docs/hw-platforms.rst
+++ b/docs/hw-platforms.rst
@@ -96,7 +96,9 @@ The library examples have been built and successfully executed on the following 
     :header-rows: 1
 
     * - MCU Platforms
-    * - `XMC1100 Boot Kit <https://www.infineon.com/cms/en/product/evaluation-boards/kit_xmc11_boot_001>`_
+    * - `KIT_XMC11_BOOT_001 <https://www.infineon.com/cms/en/product/evaluation-boards/kit_xmc11_boot_001>`_
+    * - `KIT_XMC14_2GO  <https://www.infineon.com/cms/en/product/evaluation-boards/kit_xmc14_2go>`_
+    * - `KIT_XMC47_RELAX_LITE_V1 <https://www.infineon.com/cms/de/product/evaluation-boards/kit_xmc47_relax_lite_v1>`_
     * - `Arduino Uno Rev3 <https://store.arduino.cc/arduino-uno-rev3>`_
 
 Find out which boards are build checked under continuous integration `here <https://github.com/Infineon/arduino-motix-btn99x0/blob/master/.github/workflows/build-check.yml>`_.

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
        "url":"https://github.com/Infineon/arduino-motix-btn99x0",
        "branch":"master"
     },
-    "version":"1.0.0",
+    "version":"1.1.0",
     "license":"MIT",
     "frameworks":"arduino",
     "platforms":[

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=motix-btn99x0
-version=1.0.0
+version=1.1.0
 author=Infineon Technologies
 maintainer=Infineon Technologies <www.infineon.com>
 sentence=Arduino library for the Infineon DC Motor Control Shield with BTN9970LV and BTN9990LV

--- a/src/btn99xx_dc_shield.cpp
+++ b/src/btn99xx_dc_shield.cpp
@@ -30,7 +30,7 @@ using namespace btn99x0;
     #define ACD_RESOLUTION_STEPS 1023
     #define ACD_VOLTAGE_RANGE_VOLTS 5.0
 
-#elif defined(XMC4700_Relax_Kit)
+#elif defined(XMC4700_Relax_Kit) || defined(XMC1100_XMC2GO) || defined(XMC1400_XMC2GO)
 
     #define ACD_RESOLUTION_STEPS 1023
     #define ACD_VOLTAGE_RANGE_VOLTS 3.3


### PR DESCRIPTION
Enhancements:
Added support for XMC1100_XMC2Go and XMC1400_XMC2GO in btn99xx_dc_shield.cpp.

Technical Details:

Both XMC1100_XMC2Go and XMC1400_XMC2GO operate with 3.3V logic.
The ADC (Analog-to-Digital Converter) resolution for these boards is standardized to 1024 steps (ranging from 0 to 1023).
